### PR TITLE
Quick Shulker Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
 
 	modImplementation "com.misterpemodder:shulkerboxtooltip:${project.shulkerboxtooltip_version}"
 
+	//QuickShulker support
+	modImplementation "com.github.kyrptonaught:quickshulker:${project.quickshulker_version}"
 	// Cotton Resources -- Uncomment when 1.15 is pushed, this should be modRuntime due to LibCD handling the tags.
 	// modImplementation ("io.github.cottonmc:cotton-resources:${cotton_resources_version}") { // We use our own version of modmenu and REI
 	// exclude module: "fabric-api"

--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,7 @@ dependencies {
 	modImplementation "com.misterpemodder:shulkerboxtooltip:${project.shulkerboxtooltip_version}"
 
 	//QuickShulker support
-	//modImplementation "com.github.kyrptonaught:quickshulker:${project.quickshulker_version}"
-	modImplementation "net.kyrptonaught:quickshulker:1.1.0"
+	modImplementation "net.kyrptonaught:quickshulker:${project.quickshulker_version}"
 
 	// Cotton Resources -- Uncomment when 1.15 is pushed, this should be modRuntime due to LibCD handling the tags.
 	// modImplementation ("io.github.cottonmc:cotton-resources:${cotton_resources_version}") { // We use our own version of modmenu and REI

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ repositories {
 	maven { url = "https://repo.spongepowered.org/maven" }
 	maven { url = "http://server.bbkr.space:8081/artifactory/libs-release" }
 	maven { url = "https://www.jitpack.io" }
+	maven { url   "https://dl.bintray.com/kyrptonaught/Quickshulker/"}
 }
 
 logger.lifecycle("""
@@ -67,7 +68,9 @@ dependencies {
 	modImplementation "com.misterpemodder:shulkerboxtooltip:${project.shulkerboxtooltip_version}"
 
 	//QuickShulker support
-	modImplementation "com.github.kyrptonaught:quickshulker:${project.quickshulker_version}"
+	//modImplementation "com.github.kyrptonaught:quickshulker:${project.quickshulker_version}"
+	modImplementation "net.kyrptonaught:quickshulker:1.1.0"
+
 	// Cotton Resources -- Uncomment when 1.15 is pushed, this should be modRuntime due to LibCD handling the tags.
 	// modImplementation ("io.github.cottonmc:cotton-resources:${cotton_resources_version}") { // We use our own version of modmenu and REI
 	// exclude module: "fabric-api"
@@ -95,6 +98,7 @@ dependencies {
 
 	// Annotations
 	implementation group: 'org.jetbrains', name: 'annotations', version: "${project.jetbrains_annotations}"
+	implementation 'org.jetbrains:annotations:15.0'
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ fabric_version=0.4.29+build.290-1.15
 libcd_version=2.1.1+1.15.1
 cotton_resources_version=1.4.1+1.14.4
 shulkerboxtooltip_version=1.4.5+1.15
-quickshulker_version=2658c43ebd
+quickshulker_version=1.1.1
 
 #Optional Hooks
 rei_version=3.3.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ fabric_version=0.4.29+build.290-1.15
 libcd_version=2.1.1+1.15.1
 cotton_resources_version=1.4.1+1.14.4
 shulkerboxtooltip_version=1.4.5+1.15
+quickshulker_version=-SNAPSHOT
 
 #Optional Hooks
 rei_version=3.3.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ fabric_version=0.4.29+build.290-1.15
 libcd_version=2.1.1+1.15.1
 cotton_resources_version=1.4.1+1.14.4
 shulkerboxtooltip_version=1.4.5+1.15
-quickshulker_version=-SNAPSHOT
+quickshulker_version=2658c43ebd
 
 #Optional Hooks
 rei_version=3.3.18

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Feb 26 14:39:10 EST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/i509/fabric/bulkyshulkies/api/block/base/AbstractShulkerBoxBlock.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/api/block/base/AbstractShulkerBoxBlock.java
@@ -279,8 +279,8 @@ public abstract class AbstractShulkerBoxBlock extends BlockWithEntity implements
 
 	protected abstract void openContainer(BlockPos pos, PlayerEntity playerEntity, Text displayName);
 
-    public int getSlotCount(){
-    	return this.slotCount;
+    public int getSlotCount() {
+		return this.slotCount;
 	}
 
     public interface SingleTypePropertyRetriever<T> {

--- a/src/main/java/me/i509/fabric/bulkyshulkies/api/block/base/AbstractShulkerBoxBlock.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/api/block/base/AbstractShulkerBoxBlock.java
@@ -279,7 +279,11 @@ public abstract class AbstractShulkerBoxBlock extends BlockWithEntity implements
 
 	protected abstract void openContainer(BlockPos pos, PlayerEntity playerEntity, Text displayName);
 
-	public interface SingleTypePropertyRetriever<T> {
+    public int getSlotCount(){
+    	return this.slotCount;
+	}
+
+    public interface SingleTypePropertyRetriever<T> {
 		T getFromShulker(AbstractShulkerBoxBE blockEntity);
 	}
 

--- a/src/main/java/me/i509/fabric/bulkyshulkies/api/block/base/AbstractShulkerBoxBlock.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/api/block/base/AbstractShulkerBoxBlock.java
@@ -279,11 +279,11 @@ public abstract class AbstractShulkerBoxBlock extends BlockWithEntity implements
 
 	protected abstract void openContainer(BlockPos pos, PlayerEntity playerEntity, Text displayName);
 
-    public int getSlotCount() {
+	public int getSlotCount() {
 		return this.slotCount;
 	}
 
-    public interface SingleTypePropertyRetriever<T> {
+	public interface SingleTypePropertyRetriever<T> {
 		T getFromShulker(AbstractShulkerBoxBE blockEntity);
 	}
 

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/cursed/slab/CursedSlabShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/cursed/slab/CursedSlabShulkerBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.cursed.slab;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.slab.FacingSlabShulkerBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class CursedSlabShulkerBoxBE extends FacingSlabShulkerBE {
 	public CursedSlabShulkerBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class CursedSlabShulkerBoxBE extends FacingSlabShulkerBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.slabShulkerBox");
+		return ShulkerTexts.CURSED_SLAB_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/cursed/stair/StairShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/cursed/stair/StairShulkerBoxBE.java
@@ -29,13 +29,13 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Direction;
 
 import me.i509.fabric.bulkyshulkies.api.block.base.AbstractShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class StairShulkerBoxBE extends AbstractShulkerBoxBE {
 	public StairShulkerBoxBE(BlockEntityType<?> temp, @Nullable DyeColor color) {
@@ -44,7 +44,7 @@ public class StairShulkerBoxBE extends AbstractShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.stairShulkerBox");
+		return ShulkerTexts.CURSED_STAIR_CONTAINER;
 	}
 
 	@Override

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/ender/EnderSlabBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/ender/EnderSlabBoxBE.java
@@ -25,11 +25,11 @@
 package me.i509.fabric.bulkyshulkies.block.ender;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 
 import me.i509.fabric.bulkyshulkies.api.block.slab.FacingSlabShulkerBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class EnderSlabBoxBE extends FacingSlabShulkerBE {
 	public EnderSlabBoxBE() {
@@ -38,6 +38,6 @@ public class EnderSlabBoxBE extends FacingSlabShulkerBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.enderSlab");
+		return ShulkerTexts.ENDER_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/material/copper/CopperShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/material/copper/CopperShulkerBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.material.copper;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class CopperShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 	public CopperShulkerBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class CopperShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.copperShulkerBox");
+		return ShulkerTexts.COPPER_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/material/diamond/DiamondShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/material/diamond/DiamondShulkerBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.material.diamond;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class DiamondShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 	public DiamondShulkerBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class DiamondShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.diamondShulkerBox");
+		return ShulkerTexts.DIAMOND_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/material/gold/GoldShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/material/gold/GoldShulkerBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.material.gold;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class GoldShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 	public GoldShulkerBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class GoldShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.goldShulkerBox");
+		return ShulkerTexts.GOLD_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/material/iron/IronShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/material/iron/IronShulkerBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.material.iron;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class IronShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 	public IronShulkerBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class IronShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.ironShulkerBox");
+		return ShulkerTexts.IRON_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/material/obsidian/ObsidianShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/material/obsidian/ObsidianShulkerBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.material.obsidian;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class ObsidianShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 	public ObsidianShulkerBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class ObsidianShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.obsidianShulkerBox");
+		return ShulkerTexts.OBSIDIAN_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/material/platinum/PlatinumShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/material/platinum/PlatinumShulkerBoxBE.java
@@ -35,7 +35,6 @@ import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Direction;
@@ -43,9 +42,10 @@ import net.minecraft.util.math.Direction;
 import me.i509.fabric.bulkyshulkies.BulkyShulkies;
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.api.block.base.AbstractShulkerBoxBlock;
-import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.api.event.MagnetismCollectionCallback;
+import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class PlatinumShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 	private int lastMagnetTick = 0;
@@ -150,6 +150,6 @@ public class PlatinumShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.platinumShulkerBox");
+		return ShulkerTexts.PLATINUM_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/material/silver/SilverShulkerBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/material/silver/SilverShulkerBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.material.silver;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class SilverShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 	public SilverShulkerBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class SilverShulkerBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.silverShulkerBox");
+		return ShulkerTexts.SILVER_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/block/missing/MissingTexBoxBE.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/block/missing/MissingTexBoxBE.java
@@ -27,12 +27,12 @@ package me.i509.fabric.bulkyshulkies.block.missing;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 
 import me.i509.fabric.bulkyshulkies.api.block.Facing1X1ShulkerBoxBE;
 import me.i509.fabric.bulkyshulkies.block.ShulkerBoxConstants;
 import me.i509.fabric.bulkyshulkies.registry.ShulkerBlockEntities;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class MissingTexBoxBE extends Facing1X1ShulkerBoxBE {
 	public MissingTexBoxBE(@Nullable DyeColor color) {
@@ -45,6 +45,6 @@ public class MissingTexBoxBE extends Facing1X1ShulkerBoxBE {
 
 	@Override
 	protected Text getContainerName() {
-		return new TranslatableText("container.missingTexBox");
+		return ShulkerTexts.MISSING_CONTAINER;
 	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/client/extension/QuickShulkerHookClient.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/client/extension/QuickShulkerHookClient.java
@@ -24,20 +24,23 @@
 
 package me.i509.fabric.bulkyshulkies.client.extension;
 
+import net.kyrptonaught.quickshulker.api.RegisterQuickShulkerClient;
+
+import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
+
 import me.i509.fabric.bulkyshulkies.client.screen.Generic11x7Screen;
 import me.i509.fabric.bulkyshulkies.client.screen.Generic13x7Screen;
 import me.i509.fabric.bulkyshulkies.client.screen.Generic9x7Screen;
 import me.i509.fabric.bulkyshulkies.client.screen.ScrollableScreen;
 import me.i509.fabric.bulkyshulkies.extension.QuickShulkerHook;
-import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
-import net.kyrptonaught.quickshulker.api.RegisterQuickShulkerClient;
 
 public class QuickShulkerHookClient implements RegisterQuickShulkerClient {
-	@Override
-	public void registerClient() {
-		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_9x7_CONTAINER, Generic9x7Screen::createScreen);
-		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_11x7_CONTAINER, Generic11x7Screen::createScreen);
-		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_13x7_CONTAINER, Generic13x7Screen::createScreen);
-		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_SCROLLABLE_CONTAINER, ScrollableScreen::createScreen);
-	}
+        @Override
+        public void registerClient() {
+                ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_9x7_CONTAINER, Generic9x7Screen::createScreen);
+                ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_11x7_CONTAINER, Generic11x7Screen::createScreen);
+                ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_13x7_CONTAINER, Generic13x7Screen::createScreen);
+                ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_SCROLLABLE_CONTAINER, ScrollableScreen::createScreen);
+                ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$ENDER_SLAB, ScrollableScreen::createScreen);
+        }
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/client/extension/QuickShulkerHookClient.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/client/extension/QuickShulkerHookClient.java
@@ -1,0 +1,43 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 i509VCB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package me.i509.fabric.bulkyshulkies.client.extension;
+
+import me.i509.fabric.bulkyshulkies.client.screen.Generic11x7Screen;
+import me.i509.fabric.bulkyshulkies.client.screen.Generic13x7Screen;
+import me.i509.fabric.bulkyshulkies.client.screen.Generic9x7Screen;
+import me.i509.fabric.bulkyshulkies.client.screen.ScrollableScreen;
+import me.i509.fabric.bulkyshulkies.extension.QuickShulkerHook;
+import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
+import net.kyrptonaught.quickshulker.api.RegisterQuickShulkerClient;
+
+public class QuickShulkerHookClient implements RegisterQuickShulkerClient {
+	@Override
+	public void registerClient() {
+		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_9x7_CONTAINER, Generic9x7Screen::createScreen);
+		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_11x7_CONTAINER, Generic11x7Screen::createScreen);
+		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_13x7_CONTAINER, Generic13x7Screen::createScreen);
+		ScreenProviderRegistry.INSTANCE.registerFactory(QuickShulkerHook.QS$SHULKER_SCROLLABLE_CONTAINER, ScrollableScreen::createScreen);
+	}
+}

--- a/src/main/java/me/i509/fabric/bulkyshulkies/container/GenericContainer11x7.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/container/GenericContainer11x7.java
@@ -24,13 +24,11 @@
 
 package me.i509.fabric.bulkyshulkies.container;
 
-import net.kyrptonaught.quickshulker.api.ItemStackInventory;
 import net.minecraft.container.Container;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 

--- a/src/main/java/me/i509/fabric/bulkyshulkies/container/GenericContainer11x7.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/container/GenericContainer11x7.java
@@ -24,6 +24,7 @@
 
 package me.i509.fabric.bulkyshulkies.container;
 
+import net.kyrptonaught.quickshulker.api.ItemStackInventory;
 import net.minecraft.container.Container;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
@@ -37,10 +38,10 @@ import me.i509.fabric.bulkyshulkies.BulkyShulkies;
 import me.i509.fabric.bulkyshulkies.api.SlotFactory;
 
 public class GenericContainer11x7 extends Container {
-	private final SidedInventory inventory;
+	private final Inventory inventory;
 	private final Text name;
 
-	public GenericContainer11x7(int syncId, SlotFactory slotFactory, PlayerInventory playerInventory, SidedInventory inventory, Text name) {
+	public GenericContainer11x7(int syncId, SlotFactory slotFactory, PlayerInventory playerInventory, Inventory inventory, Text name) {
 		super(null, syncId);
 		this.inventory = inventory;
 		this.name = name;

--- a/src/main/java/me/i509/fabric/bulkyshulkies/container/GenericContainer9x7.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/container/GenericContainer9x7.java
@@ -29,7 +29,6 @@ import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 
@@ -37,10 +36,10 @@ import me.i509.fabric.bulkyshulkies.BulkyShulkies;
 import me.i509.fabric.bulkyshulkies.api.SlotFactory;
 
 public class GenericContainer9x7 extends Container {
-	private final SidedInventory inventory;
+	private final Inventory inventory;
 	private final Text name;
 
-	public GenericContainer9x7(int syncId, SlotFactory slotFactory, PlayerInventory playerInventory, SidedInventory inventory, Text name) {
+	public GenericContainer9x7(int syncId, SlotFactory slotFactory, PlayerInventory playerInventory, Inventory inventory, Text name) {
 		super(null, syncId);
 		this.inventory = inventory;
 		this.name = name;

--- a/src/main/java/me/i509/fabric/bulkyshulkies/container/ScrollableContainer.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/container/ScrollableContainer.java
@@ -22,13 +22,11 @@ package me.i509.fabric.bulkyshulkies.container;
 
 import java.util.Arrays;
 
-import net.kyrptonaught.quickshulker.api.ItemStackInventory;
 import net.minecraft.container.Container;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 

--- a/src/main/java/me/i509/fabric/bulkyshulkies/container/ScrollableContainer.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/container/ScrollableContainer.java
@@ -22,10 +22,12 @@ package me.i509.fabric.bulkyshulkies.container;
 
 import java.util.Arrays;
 
+import net.kyrptonaught.quickshulker.api.ItemStackInventory;
 import net.minecraft.container.Container;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
 import net.minecraft.inventory.SidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
@@ -43,7 +45,7 @@ import me.i509.fabric.bulkyshulkies.api.SlotFactory;
  */
 public class ScrollableContainer extends Container {
 	private final Text containerName;
-	private final SidedInventory inventory;
+	private final Inventory inventory;
 	private final int rows;
 	private final int realRows;
 
@@ -52,7 +54,7 @@ public class ScrollableContainer extends Container {
 	@Environment(EnvType.CLIENT)
 	private Integer[] unsortedToSortedSlotMap;
 
-	public ScrollableContainer(int syncId, SlotFactory slotFactory, PlayerInventory playerInventory, SidedInventory inventory, Text containerName) {
+	public ScrollableContainer(int syncId, SlotFactory slotFactory, PlayerInventory playerInventory, Inventory inventory, Text containerName) {
 		super(null, syncId);
 		this.inventory = inventory;
 		this.containerName = containerName;
@@ -96,7 +98,7 @@ public class ScrollableContainer extends Container {
 		}
 	}
 
-	public SidedInventory getInventory() {
+	public Inventory getInventory() {
 		return inventory;
 	}
 

--- a/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
@@ -24,9 +24,27 @@
 
 package me.i509.fabric.bulkyshulkies.extension;
 
+import net.kyrptonaught.quickshulker.api.ItemStackInventory;
+import net.kyrptonaught.quickshulker.api.QuickOpenableRegistry;
+import net.kyrptonaught.quickshulker.api.RegisterQuickShulker;
+
+import net.minecraft.block.Block;
+import net.minecraft.container.ShulkerBoxSlot;
+import net.minecraft.container.Slot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.PacketByteBuf;
+
+import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+
 import me.i509.fabric.bulkyshulkies.BulkyShulkies;
 import me.i509.fabric.bulkyshulkies.api.block.base.AbstractShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.api.player.EnderSlabBridge;
 import me.i509.fabric.bulkyshulkies.block.cursed.slab.CursedSlabShulkerBox;
+import me.i509.fabric.bulkyshulkies.block.ender.EnderSlabBoxBlock;
 import me.i509.fabric.bulkyshulkies.block.material.copper.CopperShulkerBoxBlock;
 import me.i509.fabric.bulkyshulkies.block.material.diamond.DiamondShulkerBoxBlock;
 import me.i509.fabric.bulkyshulkies.block.material.gold.GoldShulkerBoxBlock;
@@ -38,79 +56,115 @@ import me.i509.fabric.bulkyshulkies.container.GenericContainer11x7;
 import me.i509.fabric.bulkyshulkies.container.GenericContainer13x7;
 import me.i509.fabric.bulkyshulkies.container.GenericContainer9x7;
 import me.i509.fabric.bulkyshulkies.container.ScrollableContainer;
-import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
-import net.kyrptonaught.quickshulker.api.ItemStackInventory;
-import net.kyrptonaught.quickshulker.api.QuickOpenableRegistry;
-import net.kyrptonaught.quickshulker.api.RegisterQuickShulker;
-import net.minecraft.block.Block;
-import net.minecraft.container.ShulkerBoxSlot;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.ItemStack;
-import net.minecraft.text.TranslatableText;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.PacketByteBuf;
+import me.i509.fabric.bulkyshulkies.inventory.EnderSlabInventory;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerTexts;
 
 public class QuickShulkerHook implements RegisterQuickShulker {
-	public static final Identifier QS$SHULKER_SCROLLABLE_CONTAINER = BulkyShulkies.id("qs_shulker_scrollable_container");
-	public static final Identifier QS$SHULKER_9x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_9x7");
-	public static final Identifier QS$SHULKER_11x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_11x7");
-	public static final Identifier QS$SHULKER_13x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_13x7");
+        public static final Identifier QS$SHULKER_SCROLLABLE_CONTAINER = BulkyShulkies.id("qs_shulker_scrollable_container");
+        public static final Identifier QS$SHULKER_9x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_9x7");
+        public static final Identifier QS$SHULKER_11x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_11x7");
+        public static final Identifier QS$SHULKER_13x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_13x7");
+        public static final Identifier QS$ENDER_SLAB = BulkyShulkies.id("qs_ender_slab_container");
 
-	@Override
-	public void registerProviders() {
-		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_SCROLLABLE_CONTAINER, QuickShulkerHook::createScrollable);
-		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_9x7_CONTAINER, QuickShulkerHook::create9x7);
-		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_11x7_CONTAINER, QuickShulkerHook::create11x7);
-		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_13x7_CONTAINER, QuickShulkerHook::create13x7);
+        @Override
+        public void registerProviders() {
+                ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_SCROLLABLE_CONTAINER, QuickShulkerHook::createScrollable);
+                ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_9x7_CONTAINER, QuickShulkerHook::create9x7);
+                ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_11x7_CONTAINER, QuickShulkerHook::create11x7);
+                ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_13x7_CONTAINER, QuickShulkerHook::create13x7);
+                ContainerProviderRegistry.INSTANCE.registerFactory(QS$ENDER_SLAB, QuickShulkerHook::createEnderSlab);
 
-		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
-				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-				CopperShulkerBoxBlock.class, IronShulkerBoxBlock.class, SilverShulkerBoxBlock.class, CursedSlabShulkerBox.class);
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.COPPER_CONTAINER);
+                                })), CopperShulkerBoxBlock.class);
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.IRON_CONTAINER);
+                                })), IronShulkerBoxBlock.class);
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.SILVER_CONTAINER);
+                                })), SilverShulkerBoxBlock.class);
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.CURSED_SLAB_CONTAINER);
+                                })), CursedSlabShulkerBox.class);
 
-		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER, player,
-				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-				ObsidianShulkerBoxBlock.class, PlatinumShulkerBoxBlock.class);
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.OBSIDIAN_CONTAINER);
+                                })), ObsidianShulkerBoxBlock.class);
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.PLATINUM_CONTAINER);
+                                })), PlatinumShulkerBoxBlock.class);
 
-		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_11x7_CONTAINER, player,
-				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-				DiamondShulkerBoxBlock.class);
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_11x7_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.DIAMOND_CONTAINER);
+                                })), DiamondShulkerBoxBlock.class);
 
-		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_9x7_CONTAINER, player,
-				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-				GoldShulkerBoxBlock.class);
-	}
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_9x7_CONTAINER, player,
+                                writer -> {
+                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeText(ShulkerTexts.GOLD_CONTAINER);
+                                })), GoldShulkerBoxBlock.class);
 
-	public static GenericContainer13x7 create13x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-		int invSlot = buf.readInt();
-		ItemStack stack = player.inventory.getInvStack(invSlot);
-		return new GenericContainer13x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-	}
+                QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$ENDER_SLAB, player,
+                                writer -> {
+                                        writer.writeText(ShulkerTexts.ENDER_CONTAINER);
+                                })), EnderSlabBoxBlock.class);
+        }
 
-	public static GenericContainer11x7 create11x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-		int invSlot = buf.readInt();
-		ItemStack stack = player.inventory.getInvStack(invSlot);
-		return new GenericContainer11x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-	}
+        public static GenericContainer13x7 create13x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+                int invSlot = buf.readInt();
+                Text name = buf.readText();
+                ItemStack stack = player.inventory.getInvStack(invSlot);
+                return new GenericContainer13x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), name);
+        }
 
-	public static GenericContainer9x7 create9x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-		int invSlot = buf.readInt();
-		ItemStack stack = player.inventory.getInvStack(invSlot);
-		return new GenericContainer9x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-	}
+        public static GenericContainer11x7 create11x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+                int invSlot = buf.readInt();
+                Text name = buf.readText();
+                ItemStack stack = player.inventory.getInvStack(invSlot);
+                return new GenericContainer11x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), name);
+        }
 
-	public static ScrollableContainer createScrollable(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-		int invSlot = buf.readInt();
-		ItemStack stack = player.inventory.getInvStack(invSlot);
-		return new ScrollableContainer(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-	}
+        public static GenericContainer9x7 create9x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+                int invSlot = buf.readInt();
+                Text name = buf.readText();
+                ItemStack stack = player.inventory.getInvStack(invSlot);
+                return new GenericContainer9x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), name);
+        }
 
-	public static int getSlotCount(ItemStack stack) {
-		if (stack.getItem() instanceof BlockItem) {
-			Block block = ((BlockItem) stack.getItem()).getBlock();
-			if (block instanceof AbstractShulkerBoxBlock)
-				return ((AbstractShulkerBoxBlock) block).getSlotCount();
-		}
-		return 0;
-	}
+        public static ScrollableContainer createScrollable(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+                int invSlot = buf.readInt();
+                Text name = buf.readText();
+                ItemStack stack = player.inventory.getInvStack(invSlot);
+                return new ScrollableContainer(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), name);
+        }
+
+        public static ScrollableContainer createEnderSlab(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+                Text name = buf.readText();
+                EnderSlabInventory slab = ((EnderSlabBridge) player).bridge$getEnderSlabInventory();
+                return new ScrollableContainer(syncId, Slot::new, player.inventory, slab, name);
+        }
+
+        public static int getSlotCount(ItemStack stack) {
+                if (stack.getItem() instanceof BlockItem) {
+                        Block block = ((BlockItem) stack.getItem()).getBlock();
+					if (block instanceof AbstractShulkerBoxBlock) {
+						return ((AbstractShulkerBoxBlock) block).getSlotCount();
+					}
+                }
+                return 0;
+        }
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
@@ -1,0 +1,81 @@
+package me.i509.fabric.bulkyshulkies.extension;
+
+import me.i509.fabric.bulkyshulkies.BulkyShulkies;
+import me.i509.fabric.bulkyshulkies.api.block.base.AbstractShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.client.screen.Generic11x7Screen;
+import me.i509.fabric.bulkyshulkies.client.screen.Generic13x7Screen;
+import me.i509.fabric.bulkyshulkies.client.screen.Generic9x7Screen;
+import me.i509.fabric.bulkyshulkies.client.screen.ScrollableScreen;
+import me.i509.fabric.bulkyshulkies.container.*;
+import me.i509.fabric.bulkyshulkies.registry.ShulkerBlocks;
+import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
+import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
+import net.kyrptonaught.quickshulker.api.ItemStackInventory;
+import net.kyrptonaught.quickshulker.api.QuickOpenableRegistry;
+import net.kyrptonaught.quickshulker.api.RegisterQuickShulker;
+import net.minecraft.container.ShulkerBoxSlot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.PacketByteBuf;
+
+public class QuickShulkerHook implements RegisterQuickShulker {
+   public static final Identifier QS$SHULKER_SCROLLABLE_CONTAINER = BulkyShulkies.id("qs_shulker_scrollable_container");
+   public static final Identifier QS$SHULKER_9x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_9x7");
+   public static final Identifier QS$SHULKER_11x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_11x7");
+   public static final Identifier QS$SHULKER_13x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_13x7");
+   @Override
+   public void registerProviders() {
+      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_SCROLLABLE_CONTAINER, QuickShulkerHook::createScrollable);
+      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_9x7_CONTAINER, QuickShulkerHook::create9x7);
+      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_11x7_CONTAINER, QuickShulkerHook::create11x7);
+      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_13x7_CONTAINER, QuickShulkerHook::create13x7);
+
+      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_9x7_CONTAINER, Generic9x7Screen::createScreen);
+      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_11x7_CONTAINER, Generic11x7Screen::createScreen);
+      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_13x7_CONTAINER, Generic13x7Screen::createScreen);
+      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_SCROLLABLE_CONTAINER, ScrollableScreen::createScreen);
+
+      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER,player,
+              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+              ShulkerBlocks.COPPER_SHULKER_BOX, ShulkerBlocks.IRON_SHULKER_BOX, ShulkerBlocks.SILVER_SHULKER_BOX, ShulkerBlocks.SLAB_SHULKER_BOX);
+
+      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER,player,
+              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+              ShulkerBlocks.OBSIDIAN_SHULKER_BOX, ShulkerBlocks.PLATINUM_SHULKER_BOX);
+
+      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_11x7_CONTAINER,player,
+              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+              ShulkerBlocks.DIAMOND_SHULKER_BOX);
+
+      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_9x7_CONTAINER,player,
+              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+              ShulkerBlocks.GOLD_SHULKER_BOX);
+   }
+   public static GenericContainer13x7 create13x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+      int invSlot = buf.readInt();
+      ItemStack stack = player.inventory.getInvStack(invSlot);
+      return  new GenericContainer13x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+   }
+   public static GenericContainer11x7 create11x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+      int invSlot = buf.readInt();
+      ItemStack stack = player.inventory.getInvStack(invSlot);
+      return  new GenericContainer11x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+   }
+   public static GenericContainer9x7 create9x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+      int invSlot = buf.readInt();
+      ItemStack stack = player.inventory.getInvStack(invSlot);
+      return  new GenericContainer9x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+   }
+   public static ScrollableContainer createScrollable(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+      int invSlot = buf.readInt();
+      ItemStack stack = player.inventory.getInvStack(invSlot);
+      return  new ScrollableContainer(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+   }
+   public static int getSlotCount(ItemStack stack) {
+      return ((AbstractShulkerBoxBlock) ((BlockItem) stack.getItem()).getBlock()).getSlotCount();
+
+   }
+}

--- a/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
@@ -1,18 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 i509VCB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package me.i509.fabric.bulkyshulkies.extension;
 
 import me.i509.fabric.bulkyshulkies.BulkyShulkies;
 import me.i509.fabric.bulkyshulkies.api.block.base.AbstractShulkerBoxBlock;
-import me.i509.fabric.bulkyshulkies.client.screen.Generic11x7Screen;
-import me.i509.fabric.bulkyshulkies.client.screen.Generic13x7Screen;
-import me.i509.fabric.bulkyshulkies.client.screen.Generic9x7Screen;
-import me.i509.fabric.bulkyshulkies.client.screen.ScrollableScreen;
-import me.i509.fabric.bulkyshulkies.container.*;
-import me.i509.fabric.bulkyshulkies.registry.ShulkerBlocks;
-import net.fabricmc.fabric.api.client.screen.ScreenProviderRegistry;
+import me.i509.fabric.bulkyshulkies.block.cursed.slab.CursedSlabShulkerBox;
+import me.i509.fabric.bulkyshulkies.block.material.copper.CopperShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.block.material.diamond.DiamondShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.block.material.gold.GoldShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.block.material.iron.IronShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.block.material.obsidian.ObsidianShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.block.material.platinum.PlatinumShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.block.material.silver.SilverShulkerBoxBlock;
+import me.i509.fabric.bulkyshulkies.container.GenericContainer11x7;
+import me.i509.fabric.bulkyshulkies.container.GenericContainer13x7;
+import me.i509.fabric.bulkyshulkies.container.GenericContainer9x7;
+import me.i509.fabric.bulkyshulkies.container.ScrollableContainer;
 import net.fabricmc.fabric.api.container.ContainerProviderRegistry;
 import net.kyrptonaught.quickshulker.api.ItemStackInventory;
 import net.kyrptonaught.quickshulker.api.QuickOpenableRegistry;
 import net.kyrptonaught.quickshulker.api.RegisterQuickShulker;
+import net.minecraft.block.Block;
 import net.minecraft.container.ShulkerBoxSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
@@ -22,60 +52,65 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
 public class QuickShulkerHook implements RegisterQuickShulker {
-   public static final Identifier QS$SHULKER_SCROLLABLE_CONTAINER = BulkyShulkies.id("qs_shulker_scrollable_container");
-   public static final Identifier QS$SHULKER_9x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_9x7");
-   public static final Identifier QS$SHULKER_11x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_11x7");
-   public static final Identifier QS$SHULKER_13x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_13x7");
-   @Override
-   public void registerProviders() {
-      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_SCROLLABLE_CONTAINER, QuickShulkerHook::createScrollable);
-      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_9x7_CONTAINER, QuickShulkerHook::create9x7);
-      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_11x7_CONTAINER, QuickShulkerHook::create11x7);
-      ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_13x7_CONTAINER, QuickShulkerHook::create13x7);
+	public static final Identifier QS$SHULKER_SCROLLABLE_CONTAINER = BulkyShulkies.id("qs_shulker_scrollable_container");
+	public static final Identifier QS$SHULKER_9x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_9x7");
+	public static final Identifier QS$SHULKER_11x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_11x7");
+	public static final Identifier QS$SHULKER_13x7_CONTAINER = BulkyShulkies.id("qs_shulker_container_13x7");
 
-      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_9x7_CONTAINER, Generic9x7Screen::createScreen);
-      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_11x7_CONTAINER, Generic11x7Screen::createScreen);
-      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_13x7_CONTAINER, Generic13x7Screen::createScreen);
-      ScreenProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_SCROLLABLE_CONTAINER, ScrollableScreen::createScreen);
+	@Override
+	public void registerProviders() {
+		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_SCROLLABLE_CONTAINER, QuickShulkerHook::createScrollable);
+		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_9x7_CONTAINER, QuickShulkerHook::create9x7);
+		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_11x7_CONTAINER, QuickShulkerHook::create11x7);
+		ContainerProviderRegistry.INSTANCE.registerFactory(QS$SHULKER_13x7_CONTAINER, QuickShulkerHook::create13x7);
 
-      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER,player,
-              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-              ShulkerBlocks.COPPER_SHULKER_BOX, ShulkerBlocks.IRON_SHULKER_BOX, ShulkerBlocks.SILVER_SHULKER_BOX, ShulkerBlocks.SLAB_SHULKER_BOX);
+		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
+				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+				CopperShulkerBoxBlock.class, IronShulkerBoxBlock.class, SilverShulkerBoxBlock.class, CursedSlabShulkerBox.class);
 
-      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER,player,
-              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-              ShulkerBlocks.OBSIDIAN_SHULKER_BOX, ShulkerBlocks.PLATINUM_SHULKER_BOX);
+		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER, player,
+				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+				ObsidianShulkerBoxBlock.class, PlatinumShulkerBoxBlock.class);
 
-      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_11x7_CONTAINER,player,
-              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-              ShulkerBlocks.DIAMOND_SHULKER_BOX);
+		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_11x7_CONTAINER, player,
+				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+				DiamondShulkerBoxBlock.class);
 
-      QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_9x7_CONTAINER,player,
-              writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
-              ShulkerBlocks.GOLD_SHULKER_BOX);
-   }
-   public static GenericContainer13x7 create13x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-      int invSlot = buf.readInt();
-      ItemStack stack = player.inventory.getInvStack(invSlot);
-      return  new GenericContainer13x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-   }
-   public static GenericContainer11x7 create11x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-      int invSlot = buf.readInt();
-      ItemStack stack = player.inventory.getInvStack(invSlot);
-      return  new GenericContainer11x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-   }
-   public static GenericContainer9x7 create9x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-      int invSlot = buf.readInt();
-      ItemStack stack = player.inventory.getInvStack(invSlot);
-      return  new GenericContainer9x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-   }
-   public static ScrollableContainer createScrollable(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
-      int invSlot = buf.readInt();
-      ItemStack stack = player.inventory.getInvStack(invSlot);
-      return  new ScrollableContainer(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
-   }
-   public static int getSlotCount(ItemStack stack) {
-      return ((AbstractShulkerBoxBlock) ((BlockItem) stack.getItem()).getBlock()).getSlotCount();
+		QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_9x7_CONTAINER, player,
+				writer -> writer.writeInt(player.inventory.getSlotWithStack(stack)))),
+				GoldShulkerBoxBlock.class);
+	}
 
-   }
+	public static GenericContainer13x7 create13x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+		int invSlot = buf.readInt();
+		ItemStack stack = player.inventory.getInvStack(invSlot);
+		return new GenericContainer13x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+	}
+
+	public static GenericContainer11x7 create11x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+		int invSlot = buf.readInt();
+		ItemStack stack = player.inventory.getInvStack(invSlot);
+		return new GenericContainer11x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+	}
+
+	public static GenericContainer9x7 create9x7(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+		int invSlot = buf.readInt();
+		ItemStack stack = player.inventory.getInvStack(invSlot);
+		return new GenericContainer9x7(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+	}
+
+	public static ScrollableContainer createScrollable(int syncId, Identifier identifier, PlayerEntity player, PacketByteBuf buf) {
+		int invSlot = buf.readInt();
+		ItemStack stack = player.inventory.getInvStack(invSlot);
+		return new ScrollableContainer(syncId, ShulkerBoxSlot::new, player.inventory, new ItemStackInventory(stack, getSlotCount(stack)), new TranslatableText("container.shulkerBox"));
+	}
+
+	public static int getSlotCount(ItemStack stack) {
+		if (stack.getItem() instanceof BlockItem) {
+			Block block = ((BlockItem) stack.getItem()).getBlock();
+			if (block instanceof AbstractShulkerBoxBlock)
+				return ((AbstractShulkerBoxBlock) block).getSlotCount();
+		}
+		return 0;
+	}
 }

--- a/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/extension/QuickShulkerHook.java
@@ -24,6 +24,7 @@
 
 package me.i509.fabric.bulkyshulkies.extension;
 
+import net.kyrptonaught.quickshulker.api.Util;
 import net.kyrptonaught.quickshulker.api.ItemStackInventory;
 import net.kyrptonaught.quickshulker.api.QuickOpenableRegistry;
 import net.kyrptonaught.quickshulker.api.RegisterQuickShulker;
@@ -76,45 +77,45 @@ public class QuickShulkerHook implements RegisterQuickShulker {
 
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.COPPER_CONTAINER);
                                 })), CopperShulkerBoxBlock.class);
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.IRON_CONTAINER);
                                 })), IronShulkerBoxBlock.class);
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.SILVER_CONTAINER);
                                 })), SilverShulkerBoxBlock.class);
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_SCROLLABLE_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.CURSED_SLAB_CONTAINER);
                                 })), CursedSlabShulkerBox.class);
 
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.OBSIDIAN_CONTAINER);
                                 })), ObsidianShulkerBoxBlock.class);
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_13x7_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.PLATINUM_CONTAINER);
                                 })), PlatinumShulkerBoxBlock.class);
 
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_11x7_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.DIAMOND_CONTAINER);
                                 })), DiamondShulkerBoxBlock.class);
 
                 QuickOpenableRegistry.register(((player, stack) -> ContainerProviderRegistry.INSTANCE.openContainer(QS$SHULKER_9x7_CONTAINER, player,
                                 writer -> {
-                                        writer.writeInt(player.inventory.getSlotWithStack(stack));
+                                        writer.writeInt(Util.getSlotWithStack(player.inventory,stack));
                                         writer.writeText(ShulkerTexts.GOLD_CONTAINER);
                                 })), GoldShulkerBoxBlock.class);
 

--- a/src/main/java/me/i509/fabric/bulkyshulkies/registry/ShulkerTexts.java
+++ b/src/main/java/me/i509/fabric/bulkyshulkies/registry/ShulkerTexts.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 i509VCB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package me.i509.fabric.bulkyshulkies.registry;
+
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+
+public class ShulkerTexts {
+        public static final Text CURSED_SLAB_CONTAINER = new TranslatableText("container.slabShulkerBox");
+        public static final Text CURSED_STAIR_CONTAINER = new TranslatableText("container.stairShulkerBox");
+
+        public static final Text ENDER_CONTAINER = new TranslatableText("container.enderSlab");
+
+        public static final Text COPPER_CONTAINER = new TranslatableText("container.copperShulkerBox");
+        public static final Text DIAMOND_CONTAINER = new TranslatableText("container.diamondShulkerBox");
+        public static final Text GOLD_CONTAINER = new TranslatableText("container.goldShulkerBox");
+        public static final Text IRON_CONTAINER = new TranslatableText("container.ironShulkerBox");
+        public static final Text OBSIDIAN_CONTAINER = new TranslatableText("container.obsidianShulkerBox");
+        public static final Text PLATINUM_CONTAINER = new TranslatableText("container.platinumShulkerBox");
+        public static final Text SILVER_CONTAINER = new TranslatableText("container.silverShulkerBox");
+
+
+        public static final Text MISSING_CONTAINER = new TranslatableText("container.missingTexBox");
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -51,6 +51,9 @@
     ],
     "quickshulker": [
       "me.i509.fabric.bulkyshulkies.extension.QuickShulkerHook"
+    ],
+    "quickshulker_client": [
+      "me.i509.fabric.bulkyshulkies.client.extension.QuickShulkerHookClient"
     ]
   },
   "mixins": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -48,6 +48,9 @@
     ],
     "shulkerboxtooltip": [
       "me.i509.fabric.bulkyshulkies.extension.BulkyTooltipHook"
+    ],
+    "quickshulker": [
+      "me.i509.fabric.bulkyshulkies.extension.QuickShulkerHook"
     ]
   },
   "mixins": [


### PR DESCRIPTION
This pr adds support for Quick Shulker in the QuickShulkerHook class using the entrypoint provided by quickshulker. This pr also changes the inventory type in the container from SidedInventory to just Inventory allowing my custom inventories to be used. And adds a getter for slotCount in AbstractShulkerBoxBase

Note: 
- I had issues getting quickshulker added to the project using gradle, it will need to be manually added for now.
- This currently will crash on a dedicated server, inside QuickShulkerHook there is a call to a client side method ScreenProviderRegistry.INSTANCE.registerFactory